### PR TITLE
Ensure openpyxl dependency is enforced during data loading

### DIFF
--- a/house_price_predictor.py
+++ b/house_price_predictor.py
@@ -83,6 +83,8 @@ def load_dependencies() -> Dependencies:
 
     np = ensure_dependency("numpy", "numpy")
     pd = ensure_dependency("pandas", "pandas")
+    # Ensure the default Excel engine for .xlsx files is available before reading data.
+    ensure_dependency("openpyxl", "openpyxl")
     ensemble = ensure_dependency("sklearn.ensemble", "scikit-learn")
     linear_model = ensure_dependency("sklearn.linear_model", "scikit-learn")
     metrics = ensure_dependency("sklearn.metrics", "scikit-learn")
@@ -137,6 +139,10 @@ def load_data(pd: Any, data_path: str, sheet_name: str) -> Any:
 
     try:
         df = pd.read_excel(data_path, sheet_name=sheet_name)
+    except ImportError as exc:
+        raise SystemExit(
+            "❌ Missing Excel dependency 'openpyxl'. Install it with `pip install openpyxl`."
+        ) from None
     except FileNotFoundError as exc:  # pragma: no cover - interactive feedback
         print(f"❌ File '{data_path}' not found!", file=sys.stderr)
         raise exc

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,0 +1,29 @@
+"""Tests for the load_data helper in house_price_predictor."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from house_price_predictor import load_data
+
+
+class _DummyPandas:
+    """Stub pandas module that simulates missing openpyxl dependency."""
+
+    @staticmethod
+    def read_excel(*args, **kwargs):
+        raise ImportError("No module named 'openpyxl'")
+
+
+def test_load_data_missing_openpyxl():
+    """load_data should exit with a helpful message when openpyxl is unavailable."""
+
+    with pytest.raises(SystemExit) as exc:
+        load_data(_DummyPandas, "fake.xlsx", "Sheet1")
+
+    message = str(exc.value)
+    assert "pip install openpyxl" in message
+    assert "openpyxl" in message


### PR DESCRIPTION
## Summary
- ensure the CLI checks for the openpyxl engine before attempting to read Excel files
- raise a SystemExit prompting users to install openpyxl when pandas cannot import the engine
- add a unit test that verifies the new error message when openpyxl is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68d60490083298a27231830f41a18